### PR TITLE
Fixed wrong exception description in CustomConfigurationBuilder

### DIFF
--- a/src/Sportradar.OddsFeed.SDK.API/Internal/Config/CustomConfigurationBuilder.cs
+++ b/src/Sportradar.OddsFeed.SDK.API/Internal/Config/CustomConfigurationBuilder.cs
@@ -84,7 +84,7 @@ namespace Sportradar.OddsFeed.SDK.API.Internal.Config
             }
             if (_apiHost != null && (_apiHost.ToLower().StartsWith("http://") || _apiHost.ToLower().StartsWith("https://")))
             {
-                throw new InvalidOperationException($"apiHost must not contain protocol specification. Value={_messagingHost}");
+                throw new InvalidOperationException($"apiHost must not contain protocol specification. Value={_apiHost}");
             }
         }
 


### PR DESCRIPTION
Most likely a copy-paste error, the exception description shows the wrong value (_messagingHost instead of _apiHost)