### PR TITLE
Flag should be reverted on failure to avoid failure to subsequent  call

### DIFF
--- a/src/Sportradar.OddsFeed.SDK.API/Feed.cs
+++ b/src/Sportradar.OddsFeed.SDK.API/Feed.cs
@@ -511,6 +511,8 @@ namespace Sportradar.OddsFeed.SDK.API
             }
             catch (CommunicationException ex)
             {
+                Interlocked.CompareExchange(ref _opened, 0, 1);
+
                 // this should really almost never happen
                 var result = _connectionValidator.ValidateConnection();
                 if (result == ConnectionValidationResult.Success)
@@ -529,6 +531,8 @@ namespace Sportradar.OddsFeed.SDK.API
             }
             catch (BrokerUnreachableException ex)
             {
+                Interlocked.CompareExchange(ref _opened, 0, 1);
+
                 // this should really almost never happen
                 var result = _connectionValidator.ValidateConnection();
                 if (result == ConnectionValidationResult.Success)


### PR DESCRIPTION
This is to address [issue regarding check being done during feed open](https://github.com/sportradar/UnifiedOddsSdkNet/issues/7).

On each exception, the flag should be reverted to allow subsequent call to go through without throwing exception during check.